### PR TITLE
Fix the usage of dict object

### DIFF
--- a/pi_gpio/sockets.py
+++ b/pi_gpio/sockets.py
@@ -14,15 +14,15 @@ def pin_list():
 
 @socketio.on('pin:read')
 def pin_read(data):
-    response = PIN_MANAGER.read_one(data.num)
+    response = PIN_MANAGER.read_one(data['num'])
     emit('pin:read', response)
 
 
 @socketio.on('pin:write')
 def pin_write(data):
-    result = PIN_MANAGER.update_value(data.num, data.value)
+    result = PIN_MANAGER.update_value(data['num'], data['value'])
     if not result:
         emit('pin:write', {'message': 'Pin not found'})
     else:
-        response = PIN_MANAGER.read_one(data.num)
+        response = PIN_MANAGER.read_one(data['num'])
         emit('pin:write', response)


### PR DESCRIPTION
When I am reading the pin value of num 7:

``` javascript
socket.emit('pin:read', { num : 7 } );
```

Server raises errors:

``` sh
pi@raspberrypi:~/Pi-GPIO-Server $ !sudo
sudo python pi_gpio_server.py
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/gevent/greenlet.py", line 327, in run
    result = self._run(*self.args, **self.kwargs)
  File "/usr/local/lib/python2.7/dist-packages/socketio/virtsocket.py", line 403, in _receiver_loop
    retval = pkt_ns.process_packet(pkt)
  File "/usr/local/lib/python2.7/dist-packages/socketio/namespace.py", line 155, in process_packet
    return self.process_event(packet)
  File "/usr/local/lib/python2.7/dist-packages/flask_socketio/__init__.py", line 58, in process_event
    return self.socketio._dispatch_message(app, self, message, args)
  File "/usr/local/lib/python2.7/dist-packages/flask_socketio/__init__.py", line 127, in _dispatch_message
    ret = self.messages[namespace.ns_name][message](*args)
  File "/home/pi/Pi-GPIO-Server/pi_gpio/sockets.py", line 17, in pin_read
    response = PIN_MANAGER.read_one(data.num)
AttributeError: 'dict' object has no attribute 'num'
<Greenlet at 0x76232030: <bound method Socket._receiver_loop of <socketio.virtsocket.Socket object at 0x762369d0>>> failed with AttributeError
```
