### PR TITLE
Set the default bouncetime value to -666

### DIFF
--- a/pi_gpio/events.py
+++ b/pi_gpio/events.py
@@ -30,6 +30,6 @@ class PinEventManager(PinManager):
             name = config.get('name', '')
             if event:
                 edge = self.edge[event]
-                bounce = config['bounce']
+                bounce = config.get('bounce', -666)
                 cb = self.build_event_callback(num, name, event)
                 self.gpio.add_event_detect(num, edge, callback=cb, bouncetime=bounce)


### PR DESCRIPTION
Set the default bouncetime to -666 (the default value -666 is in Rpi.GPIO source code).

As-Is: if the bouncetime is not set, your setting for event detecting is silently down. And there is no notification that bouncetime is required.
